### PR TITLE
add mystrom switches for hallway and offices

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -84,6 +84,8 @@
       entity_id:
       - switch.systvscreen
       - switch.kafiscreen
+      - switch.gangscreen
+      - switch.swoascreen
 
 - alias: Office Screens Off
   trigger:
@@ -99,7 +101,9 @@
       entity_id:
       - switch.systvscreen
       - switch.kafiscreen
-      - switch.rubydashboard
+      - switch.gangscreen
+      - switch.swoascreen
+      - switch.rubyscreen
 
 - alias: Ruby Screen On
   trigger:
@@ -113,7 +117,7 @@
   - service: switch.turn_on
     data:
       entity_id:
-      - switch.rubydashboard
+      - switch.rubyscreen
 
 - alias: Coffee Machine On
   trigger:

--- a/customize.yaml
+++ b/customize.yaml
@@ -37,9 +37,15 @@
     switch.kafiscreen:
       friendly_name: 'Kafi Screen'
       icon: mdi:television
-    switch.rubydashboard:
-      friendly_name: 'Ruby Status Dashboard'
+    switch.rubyscreen:
+      friendly_name: 'Ruby Status Screen'
       icon: mdi:television
+    switch.gangscreen:
+      friendly_name: 'Eingang Screen'
+      icon: mdi:television
+    switch.swoascreen:
+      friendly_name: 'SWOA Screen'
+      icon: mdi:televison
 
     automation.automatic_bar_lighting:                  
       friendly_name: 'Automatic Lighting'

--- a/groups.yaml
+++ b/groups.yaml
@@ -38,12 +38,14 @@
     entities:
     - light.sonoff1905
     - input_boolean.sonoff1905_timebased_lighting
+    - switch.gangscreen
   devtre:
     name: '/dev/tre'
     control: hidden
     entities:
     - light.sonoff1645
     - input_boolean.sonoff1645_timebased_lighting
+    - switch.swoascreen
   ruby:
     name: '/dev/ruby'
     control: hidden

--- a/switches.yaml
+++ b/switches.yaml
@@ -38,4 +38,10 @@
   name: kafiscreen
 - platform: mystrom
   host: 10.14.1.17
-  name: rubydashboard
+  name: rubyscreen
+- platform: mystrom
+  host: 10.14.1.13
+  name: gangscreen
+- platform: mystrom
+  host: 10.14.1.24
+  name: swoascreen


### PR DESCRIPTION
add two new mystrom switches for screens in the hallway and the /dev/tre office.

unified the naming from "rubydashboard" to "rubyscreen"