### PR TITLE
add mystrom switches

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -86,6 +86,7 @@
       - switch.kafiscreen
       - switch.gangscreen
       - switch.swoascreen
+      - switch.druckerscreen
 
 - alias: Office Screens Off
   trigger:
@@ -103,6 +104,7 @@
       - switch.kafiscreen
       - switch.gangscreen
       - switch.swoascreen
+      - switch.druckerscreen
       - switch.rubyscreen
 
 - alias: Ruby Screen On

--- a/customize.yaml
+++ b/customize.yaml
@@ -46,6 +46,9 @@
     switch.swoascreen:
       friendly_name: 'SWOA Screen'
       icon: mdi:televison
+    switch.druckerscreen:
+      friendly_name: 'Screen beim Drucker'
+      icon: mdi:television
 
     automation.automatic_bar_lighting:                  
       friendly_name: 'Automatic Lighting'

--- a/switches.yaml
+++ b/switches.yaml
@@ -45,3 +45,6 @@
 - platform: mystrom
   host: 10.14.1.24
   name: swoascreen
+- platform: mystrom
+  host: 10.14.1.28
+  name: druckerscreen


### PR DESCRIPTION
This adds the screen over the printer into the automation with the usual schedule.